### PR TITLE
Improved IntelliJ IDEA support

### DIFF
--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtBasePlugin.java
@@ -35,6 +35,7 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.idea.IdeaPlugin;
 
 public class GwtBasePlugin implements Plugin<Project> {
 	public static final String GWT_TASK_GROUP = "GWT";
@@ -158,6 +159,14 @@ public class GwtBasePlugin implements Plugin<Project> {
 					@Override
 					public void execute(EclipsePlugin eclipsePlugin) {
 						new GwtEclipsePlugin().apply(project, GwtBasePlugin.this);
+					}
+				});
+
+		project.getPlugins().withType(IdeaPlugin.class,
+				new Action<IdeaPlugin>() {
+					@Override
+					public void execute(IdeaPlugin ideaPlugin) {
+						new GwtIdeaPlugin().apply(project, GwtBasePlugin.this);
 					}
 				});
 	}

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtIdeaPlugin.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtIdeaPlugin.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2013 Steffen Schaefer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.richsource.gradle.plugins.gwt;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+import org.gradle.plugins.ide.idea.IdeaPlugin;
+import org.gradle.plugins.ide.idea.model.IdeaModel;
+
+import java.util.Collection;
+
+/**
+ * This "plugin" improves the IntelliJ IDEA integration by adding
+ * the gwt dependencies to the project.
+ *
+ * idea {
+ *     module {
+ *         scopes.PROVIDED.plus  += configurations.gwtSdk
+ *         scopes.PROVIDED.plus  += configurations.gwt
+ *     }
+ * }
+ */
+public class GwtIdeaPlugin {
+
+	private static final String SCOPE_PROVIDED = "PROVIDED";
+	private static final String KEY_PLUS = "plus";
+
+	public void apply(final Project project, final GwtBasePlugin gwtBasePlugin) {
+		project.getPlugins().apply(IdeaPlugin.class);
+
+		project.afterEvaluate(new Action<Project>() {
+			@Override
+			public void execute(final Project project) {
+				IdeaModel ideaModel = project.getExtensions().getByType(IdeaModel.class);
+				Collection<Configuration> configurations =
+						ideaModel.getModule().getScopes().get(SCOPE_PROVIDED).get(KEY_PLUS);
+
+				Configuration gwtSdkConfiguration = gwtBasePlugin.getGwtSdkConfiguration();
+				Configuration gwtConfiguration = gwtBasePlugin.getGwtConfiguration();
+
+				configurations.add(gwtSdkConfiguration);
+				configurations.add(gwtConfiguration);
+			}
+		});
+	}
+}


### PR DESCRIPTION
In the current situation IntelliJ does not know about the `gwt` configuration and any dependencies added to it are shows as import errors. This can be solved by adding the following code block to the build scripts:

``` groovy
idea {
    module {
        scopes.PROVIDED.plus  += configurations.gwt
        scopes.PROVIDED.plus  += configurations.gwtSdk
    }
}
```

This is essentially what the first commit does automatically.

The next problem is that IntelliJ isn't handling sources artifacts properly, which can be solved by splitting the `gwt`  configuration up into two:

``` groovy
configurations {
    gwtCompile
    gwtSources
    gwt.extendsFrom(gwtSources, gwtCompile)
}
```

and adjusting the first snippet to only add `configurations.gwtCompile` instead of `configurations.gwt`. That is what the second commit is doing.

The example dependency declaration now looks like this:

``` groovy
dependencies {
    gwtCompile 'foo:bar:1.2.3'  
    gwtSources 'foo:bar:1.2.3:sources'
}
```

The old dependency declaration with `gwt` should still work, but won't be used by the IntelliJ integration.
