### PR TITLE
extraJvmArgs property for GWT task

### DIFF
--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/AbstractGwtActionTask.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/AbstractGwtActionTask.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
@@ -50,9 +52,11 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
 	private final String main;
 	
 	private List<Object> args = new ArrayList<Object>();
-	
+
+	private String extraJvmArgs;
+
 	private List<Object> jvmArgs = new ArrayList<Object>();
-	
+
 	private boolean debug;
 	
 	private LogLevel logLevel;
@@ -99,8 +103,10 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
 				argOnOff(getIncremental(), "-incremental", "-noincremental");
 				argIfSet("-sourceLevel", getSourceLevel());
 				argIfSet("-logLevel", getLogLevel());
-				
+
+				addExtraJvmArgs();
 				addArgs();
+
 				javaExecSpec.jvmArgs(jvmArgs);
 				javaExecSpec.args(args);
 				// the module names are expected to be the last parameters
@@ -108,6 +114,12 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
 			}
 		}));
 		execResult.assertNormalExitValue().rethrowFailure();
+	}
+
+	private void addExtraJvmArgs() {
+		Matcher m = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(getExtraJvmArgs());
+		while (m.find())
+			this.jvmArgs.add(m.group(1));
 	}
 
 	/**
@@ -238,6 +250,14 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
 	 */
 	public void setMaxHeapSize(String maxHeapSize) {
 		this.maxHeapSize = maxHeapSize;
+	}
+
+	public String getExtraJvmArgs() {
+		return extraJvmArgs;
+	}
+
+	public void setExtraJvmArgs(String value) {
+		extraJvmArgs = value;
 	}
 
 	public boolean isDebug() {

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtBasePlugin.java
@@ -263,6 +263,12 @@ public class GwtBasePlugin implements Plugin<Project> {
 						return mainSourceSet.getCompileClasspath().plus(project.files(mainSourceSet.getOutput().getClassesDir()));
 					}
 				});
+				conventionMapping.map("extraJvmArgs", new Callable<String>() {
+					@Override
+					public String call() throws Exception {
+						return extension.getExtraJvmArgs();
+					}
+				});
 				conventionMapping.map("minHeapSize", new Callable<String>() {
 					@Override
 					public String call() throws Exception {

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtPluginExtension.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtPluginExtension.java
@@ -47,7 +47,8 @@ public class GwtPluginExtension {
 
 	private Boolean incremental;
 	private JsInteropMode jsInteropMode;
-	
+
+	private String extraJvmArgs = "";
 	private String minHeapSize = "256M";
 	private String maxHeapSize = "256M";
 	
@@ -152,6 +153,14 @@ public class GwtPluginExtension {
 
 	public void setLogLevel(LogLevel logLevel) {
 		this.logLevel = logLevel;
+	}
+
+	public String getExtraJvmArgs() {
+		return extraJvmArgs;
+	}
+
+	public void setExtraJvmArgs(String extraJvmArgs) {
+		this.extraJvmArgs = extraJvmArgs;
 	}
 
 	public String getMinHeapSize() {


### PR DESCRIPTION
Hello!

I added a new property extraJvmArgs for GWT task (as in GWT maven plugin). This value will be tokenized and passed to forked java process for GWT compiler as additional arguments.

```
gwt {
    gwtVersion="2.6.1";
    minHeapSize = "512M";
    maxHeapSize = "1024M";

    extraJvmArgs="-Djava.io.tmpdir=/run/shm"

    modules = ['org.example.MyModule']
    src = files('src/main/java', 'build/resources/main')
}
```
