### PR TITLE
Allow setting of arbitrary JVM arguments

### DIFF
--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/AbstractGwtActionTask.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/AbstractGwtActionTask.java
@@ -142,6 +142,15 @@ public abstract class AbstractGwtActionTask extends DefaultTask {
 		this.jvmArgs.addAll(Arrays.asList(args));
 	}
 
+	public void setJvmArgs(List<Object> args) {
+		this.jvmArgs.clear();
+		this.jvmArgs.addAll(args);
+	}
+
+	public List<Object> getJvmArgs() {
+		return this.jvmArgs;
+	}
+
 	protected void argIfEnabled(Boolean condition, String arg) {
 		if (Boolean.TRUE.equals(condition)) {
 			args(arg);

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/AbstractGwtCompile.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/AbstractGwtCompile.java
@@ -16,6 +16,7 @@
 package de.richsource.gradle.plugins.gwt;
 
 import java.io.File;
+import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.gradle.api.internal.IConventionAware;
@@ -66,6 +67,7 @@ public class AbstractGwtCompile extends AbstractGwtTask implements GwtCompileOpt
 		argOnOff(getOverlappingSourceWarnings(), "-overlappingSourceWarnings", "-nooverlappingSourceWarnings");
 		argOnOff(getSaveSource(), "-saveSource", "-nosaveSource");
 		argIfSet("-saveSourceOutput", getSaveSourceOutput());
+		jvmArgs(getJvmArgs().toArray());
 	}
 	
 	protected void configure(final GwtCompileOptions options) {
@@ -410,5 +412,15 @@ public class AbstractGwtCompile extends AbstractGwtTask implements GwtCompileOpt
 	@Override
 	public void setSaveSourceOutput(File saveSourceOutput) {
 		options.setSaveSourceOutput(saveSourceOutput);
+	}
+
+	@Override
+	public void setJvmArgs(Object... args) {
+	       options.setJvmArgs(args);
+	}
+
+	@Override
+	public List<Object> getJvmArgs() {
+	       return options.getJvmArgs();
 	}
 }

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtBasePlugin.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtBasePlugin.java
@@ -302,6 +302,12 @@ public class GwtBasePlugin implements Plugin<Project> {
 						return extension.getJsInteropMode();
 					}
 				});
+				conventionMapping.map("jvmArgs", new Callable<List<Object>>() {
+					@Override
+					public List<Object> call() throws Exception {
+						return extension.getJvmArgs();
+					}
+				});
 			}});
 	}
 	

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtCompileOptions.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtCompileOptions.java
@@ -16,6 +16,7 @@
 package de.richsource.gradle.plugins.gwt;
 
 import java.io.File;
+import java.util.List;
 
 
 /**
@@ -233,4 +234,9 @@ public interface GwtCompileOptions {
 	 * @param saveSourceOutput the saveSourceOutput to set
 	 */
 	void setSaveSourceOutput(File saveSourceOutput);
+
+	List<Object> getJvmArgs();
+
+	void setJvmArgs(Object... args);
+
 }

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtPluginExtension.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/GwtPluginExtension.java
@@ -55,6 +55,7 @@ public class GwtPluginExtension {
 	private final GwtSuperDevOptions superDev = new GwtSuperDevOptionsImpl();
 	private final GwtCompileOptions compiler = new GwtCompileOptionsImpl();
 	private final GwtTestOptions test = new GwtTestOptions();
+	private List<Object> jvmArgs = new ArrayList<Object>();
 
 	public List<String> getModules() {
 		return modules;
@@ -244,5 +245,14 @@ public class GwtPluginExtension {
 
 	public void setModulePathPrefix(String modulePathPrefix) {
 		this.modulePathPrefix = modulePathPrefix;
+	}
+
+	public List<Object> getJvmArgs() {
+		return jvmArgs;
+	}
+
+	public void setJvmArgs(List<Object> jvmArgs) {
+		this.jvmArgs.clear();
+		this.jvmArgs.addAll(jvmArgs);
 	}
 }

--- a/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/internal/GwtCompileOptionsImpl.java
+++ b/gwt-gradle-plugin/src/main/java/de/richsource/gradle/plugins/gwt/internal/GwtCompileOptionsImpl.java
@@ -16,6 +16,9 @@
 package de.richsource.gradle.plugins.gwt.internal;
 
 import java.io.File;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import de.richsource.gradle.plugins.gwt.GwtCompileOptions;
 import de.richsource.gradle.plugins.gwt.Namespace;
@@ -60,6 +63,8 @@ public class GwtCompileOptionsImpl implements GwtCompileOptions {
 	private Boolean overlappingSourceWarnings;
 	private Boolean saveSource;
 	private File saveSourceOutput;
+
+	private List<Object> jvmArgs = new ArrayList<Object>();
 
 	/** {@inheritDoc} */
 	@Override
@@ -361,4 +366,15 @@ public class GwtCompileOptionsImpl implements GwtCompileOptions {
 	public void setSaveSourceOutput(File saveSourceOutput) {
 		this.saveSourceOutput = saveSourceOutput;
 	}
+
+	@Override
+	public List<Object> getJvmArgs() {
+	    return jvmArgs;
+	}
+
+	@Override
+	public void setJvmArgs(Object... args) {
+	     jvmArgs.addAll(Arrays.asList(args));
+	}
+
 }


### PR DESCRIPTION
Ex: gwt {
  jvmArgs = [ '-Djava.io.tmpdir=/gwt-tmp' ]
}