### PR TITLE
Fix some typos in to documentation

### DIFF
--- a/doc/0.1/index.md
+++ b/doc/0.1/index.md
@@ -129,7 +129,7 @@ If your project uses the “gwt” plugin together with the “eclipse” and �
 
 ## How to debug Development Mode?
 
-When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debuger to attach to port 5005.
+When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debugger to attach to port 5005.
 Now you can configure your IDE to connect to that debug port.
 
 ## How to run Super Dev Mode?

--- a/doc/0.2/index.md
+++ b/doc/0.2/index.md
@@ -129,7 +129,7 @@ If your project uses the “gwt” plugin together with the “eclipse” and �
 
 ## How to debug Development Mode?
 
-When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debuger to attach to port 5005.
+When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debugger to attach to port 5005.
 Now you can configure your IDE to connect to that debug port.
 
 ## How to run Super Dev Mode?

--- a/doc/0.3/index.md
+++ b/doc/0.3/index.md
@@ -129,7 +129,7 @@ If your project uses the “gwt” plugin together with the “eclipse” and �
 
 ## How to debug Development Mode?
 
-When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debuger to attach to port 5005.
+When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debugger to attach to port 5005.
 Now you can configure your IDE to connect to that debug port.
 
 ## How to run Super Dev Mode?

--- a/doc/0.4/configuration.md
+++ b/doc/0.4/configuration.md
@@ -6,7 +6,7 @@ title :  "Configuration"
 ### Plugin configuration
 
 The plugin registers an extension named "gwt" of type [GwtPluginExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtPluginExtension.html) with the Gradle model. This extension defines the conventions/defaults for all GWT related tasks. If you use the extension to do the configuration, the plugin ensures that the configuration properties are consistently set as default values to all related tasks.
-All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that a re specific to one kind of task are defined in specific sub-objects.
+All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that are specific to one kind of task are defined in specific sub-objects.
 
 An example of both kinds of properties looks this way:
 
@@ -55,10 +55,10 @@ In the following list you can find the interfaces/classes that define specific t
 
 The plugin's support of testing is not based on a custom task but instead extends the existing Test task of Gradle.
 
-To do this, every instance of Gradle's Test task is dynamically extended to have a prperty "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
+To do this, every instance of Gradle's Test task is dynamically extended to have a property "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
 In addition, an instance of [GwtTestOptions](javadoc/de/richsource/gradle/plugins/gwt/GwtTestOptions.html) is added as property "test" to the plugin's extension object. Using this, you can again specify defaults for all instances of the Test task.
 
-To activate the manipulation of Test tasks to support GWT tests, you have to add the foollowing to your build.gradle:
+To activate the manipulation of Test tasks to support GWT tests, you have to add the following to your build.gradle:
 
 {% highlight groovy linenos=table %}
 gwt {
@@ -106,4 +106,4 @@ gwt {
 }
 {% endhighlight %}
 
-The availeble log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).
+The available log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).

--- a/doc/0.4/project_types.md
+++ b/doc/0.4/project_types.md
@@ -47,7 +47,7 @@ gwt {
 }
 {% endhighlight %}
 
-As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible the this task is called by setting appropriate task dependencies.
+As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible that this task is called by setting appropriate task dependencies.
 
 Typical use-cases for this are:
 * Uploading the GWT compiler output to a maven repository to be consumed by other projects.

--- a/doc/0.4/quickstart.md
+++ b/doc/0.4/quickstart.md
@@ -75,5 +75,5 @@ If you want to start the GWT development mode simply call "gradle gwtDev".
 
 ## How to debug Development Mode?
 
-When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debuger to attach to port 5005.
+When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debugger to attach to port 5005.
 Now you can configure your IDE to connect to that debug port.

--- a/doc/0.5/configuration.md
+++ b/doc/0.5/configuration.md
@@ -6,7 +6,7 @@ title :  "Configuration"
 ### Plugin configuration
 
 The plugin registers an extension named "gwt" of type [GwtPluginExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtPluginExtension.html) with the Gradle model. This extension defines the conventions/defaults for all GWT related tasks. If you use the extension to do the configuration, the plugin ensures that the configuration properties are consistently set as default values to all related tasks.
-All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that a re specific to one kind of task are defined in specific sub-objects.
+All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that are specific to one kind of task are defined in specific sub-objects.
 
 An example of both kinds of properties looks this way:
 
@@ -55,10 +55,10 @@ In the following list you can find the interfaces/classes that define specific t
 
 The plugin's support of testing is not based on a custom task but instead extends the existing Test task of Gradle.
 
-To do this, every instance of Gradle's Test task is dynamically extended to have a prperty "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
+To do this, every instance of Gradle's Test task is dynamically extended to have a property "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
 In addition, an instance of [GwtTestOptions](javadoc/de/richsource/gradle/plugins/gwt/GwtTestOptions.html) is added as property "test" to the plugin's extension object. Using this, you can again specify defaults for all instances of the Test task.
 
-To activate the manipulation of Test tasks to support GWT tests, you have to add the foollowing to your build.gradle:
+To activate the manipulation of Test tasks to support GWT tests, you have to add the following to your build.gradle:
 
 {% highlight groovy linenos=table %}
 gwt {
@@ -106,4 +106,4 @@ gwt {
 }
 {% endhighlight %}
 
-The availeble log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).
+The available log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).

--- a/doc/0.5/project_types.md
+++ b/doc/0.5/project_types.md
@@ -47,7 +47,7 @@ gwt {
 }
 {% endhighlight %}
 
-As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible the this task is called by setting appropriate task dependencies.
+As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible that this task is called by setting appropriate task dependencies.
 
 Typical use-cases for this are:
 * Uploading the GWT compiler output to a maven repository to be consumed by other projects.

--- a/doc/0.5/quickstart.md
+++ b/doc/0.5/quickstart.md
@@ -75,5 +75,5 @@ If you want to start the GWT development mode simply call "gradle gwtDev".
 
 ## How to debug Development Mode?
 
-When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debuger to attach to port 5005.
+When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debugger to attach to port 5005.
 Now you can configure your IDE to connect to that debug port.

--- a/doc/0.6/configuration.md
+++ b/doc/0.6/configuration.md
@@ -6,7 +6,7 @@ title :  "Configuration"
 ### Plugin configuration
 
 The plugin registers an extension named "gwt" of type [GwtPluginExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtPluginExtension.html) with the Gradle model. This extension defines the conventions/defaults for all GWT related tasks. If you use the extension to do the configuration, the plugin ensures that the configuration properties are consistently set as default values to all related tasks.
-All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that a re specific to one kind of task are defined in specific sub-objects.
+All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that are specific to one kind of task are defined in specific sub-objects.
 
 An example of both kinds of properties looks this way:
 
@@ -55,10 +55,10 @@ In the following list you can find the interfaces/classes that define specific t
 
 The plugin's support of testing is not based on a custom task but instead extends the existing Test task of Gradle.
 
-To do this, every instance of Gradle's Test task is dynamically extended to have a prperty "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
+To do this, every instance of Gradle's Test task is dynamically extended to have a property "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
 In addition, an instance of [GwtTestOptions](javadoc/de/richsource/gradle/plugins/gwt/GwtTestOptions.html) is added as property "test" to the plugin's extension object. Using this, you can again specify defaults for all instances of the Test task.
 
-To activate the manipulation of Test tasks to support GWT tests, you have to add the foollowing to your build.gradle:
+To activate the manipulation of Test tasks to support GWT tests, you have to add the following to your build.gradle:
 
 {% highlight groovy linenos=table %}
 gwt {
@@ -106,4 +106,4 @@ gwt {
 }
 {% endhighlight %}
 
-The availeble log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).
+The available log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).

--- a/doc/0.6/project_types.md
+++ b/doc/0.6/project_types.md
@@ -47,7 +47,7 @@ gwt {
 }
 {% endhighlight %}
 
-As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible the this task is called by setting appropriate task dependencies.
+As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible that this task is called by setting appropriate task dependencies.
 
 Typical use-cases for this are:
 * Uploading the GWT compiler output to a maven repository to be consumed by other projects.

--- a/doc/0.6/quickstart.md
+++ b/doc/0.6/quickstart.md
@@ -84,5 +84,5 @@ If you want to start the GWT development mode simply call "gradle gwtDev".
 
 ## How to debug Development Mode?
 
-When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debuger to attach to port 5005.
+When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debugger to attach to port 5005.
 Now you can configure your IDE to connect to that debug port.

--- a/doc/latest/configuration.md
+++ b/doc/latest/configuration.md
@@ -6,7 +6,7 @@ title :  "Configuration"
 ### Plugin configuration
 
 The plugin registers an extension named "gwt" of type [GwtPluginExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtPluginExtension.html) with the Gradle model. This extension defines the conventions/defaults for all GWT related tasks. If you use the extension to do the configuration, the plugin ensures that the configuration properties are consistently set as default values to all related tasks.
-All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that a re specific to one kind of task are defined in specific sub-objects.
+All properties that are common to multiple/all GWT related tasks are defined in the extension itself (e.g. used GWT modules). Properties that are specific to one kind of task are defined in specific sub-objects.
 
 An example of both kinds of properties looks this way:
 
@@ -55,10 +55,10 @@ In the following list you can find the interfaces/classes that define specific t
 
 The plugin's support of testing is not based on a custom task but instead extends the existing Test task of Gradle.
 
-To do this, every instance of Gradle's Test task is dynamically extended to have a prperty "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
+To do this, every instance of Gradle's Test task is dynamically extended to have a property "gwt" of type [GwtTestExtension](javadoc/de/richsource/gradle/plugins/gwt/GwtTestExtension.html).
 In addition, an instance of [GwtTestOptions](javadoc/de/richsource/gradle/plugins/gwt/GwtTestOptions.html) is added as property "test" to the plugin's extension object. Using this, you can again specify defaults for all instances of the Test task.
 
-To activate the manipulation of Test tasks to support GWT tests, you have to add the foollowing to your build.gradle:
+To activate the manipulation of Test tasks to support GWT tests, you have to add the following to your build.gradle:
 
 {% highlight groovy linenos=table %}
 gwt {
@@ -106,4 +106,4 @@ gwt {
 }
 {% endhighlight %}
 
-The availeble log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).
+The available log levels are defined in the enum [LogLevel](javadoc/de/richsource/gradle/plugins/gwt/LogLevel.html).

--- a/doc/latest/project_types.md
+++ b/doc/latest/project_types.md
@@ -47,7 +47,7 @@ gwt {
 }
 {% endhighlight %}
 
-As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible the this task is called by setting appropriate task dependencies.
+As nobody but you knows what you want to do with the GWT compiler output, the plugin does nothing else than configuring the task "compileGwt". You are responsible that this task is called by setting appropriate task dependencies.
 
 Typical use-cases for this are:
 * Uploading the GWT compiler output to a maven repository to be consumed by other projects.

--- a/doc/latest/quickstart.md
+++ b/doc/latest/quickstart.md
@@ -84,5 +84,5 @@ If you want to start the GWT development mode simply call "gradle gwtDev".
 
 ## How to debug Development Mode?
 
-When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debuger to attach to port 5005.
+When running the task “gwtDev” you can specify a system property “-DgwtDev.debug=true” to enable debugging. This causes the build to stop when starting development mode and waiting for a debugger to attach to port 5005.
 Now you can configure your IDE to connect to that debug port.


### PR DESCRIPTION
While reading through your documentation, I found a few typos and fixed them